### PR TITLE
Add personalized nutrition analysis and meal plan system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# li_test_repo
+# Personalized Nutrition Analysis & Meal Plan System
+
+This repository implements a nutrition analysis engine that:
+
+- Calculates caloric and macronutrient requirements using the Mifflin-St Jeor formula.
+- Generates goal-aligned meal plans from an included dish database.
+- Respects optional dietary preferences (e.g., Vegetarian, Low-Carb).
+- Exports meal plans with report-ready visualizations (PDF and Excel).
+- Provides utilities to generate synthetic user datasets for testing.
+
+## Getting Started
+
+1. Create and activate a Python 3.10 environment.
+2. Install the required packages:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Run the automated tests:
+
+   ```bash
+   python -m unittest discover
+   ```
+
+## Command Line Usage
+
+The `nutrition_cli.py` script allows you to run the analysis from the command line. Example:
+
+```bash
+python nutrition_cli.py --age 30 --gender Male --weight 82 --height 182 \
+  --goal "muscle gain" --activity-level moderate --preferences Vegetarian \
+  --meals 3 --alt-meals 2,4 --top 2 --export --show-json
+```
+
+This command will output recommended meal plans, create charts, and export the best match to both Excel (`reports/meal_plan.xlsx`) and PDF (`reports/nutrition_report.pdf`).
+
+### Synthetic Dataset Generation
+
+You can generate a synthetic dataset of users with nutritional targets through the API:
+
+```python
+from pathlib import Path
+from nutrition_system import generate_synthetic_user_dataset
+
+dataset = generate_synthetic_user_dataset(10, output_path=Path("synthetic_users.json"))
+```
+
+## Repository Contents
+
+- `nutrition_system.py`: Core nutrition analysis, meal planning, charting, and export logic.
+- `nutrition_cli.py`: Command line script for end-to-end analysis and report creation.
+- `dish_database.json`: Structured dataset of dishes with nutritional information and tags.
+- `tests/test_nutrition_system.py`: Unit tests covering core functionality and exports.
+- `requirements.txt`: Python dependencies required for the analysis and reporting modules.

--- a/dish_database.json
+++ b/dish_database.json
@@ -1,0 +1,102 @@
+[
+  {
+    "dish_name": "Grilled Chicken Salad",
+    "ingredients": ["Chicken Breast", "Mixed Greens", "Cherry Tomatoes", "Olive Oil"],
+    "serving_size": 350,
+    "calories": 420,
+    "protein": 38,
+    "fat": 18,
+    "carbs": 28,
+    "tags": ["High-Protein", "Low-Carb"]
+  },
+  {
+    "dish_name": "Quinoa and Black Bean Bowl",
+    "ingredients": ["Quinoa", "Black Beans", "Bell Peppers", "Corn", "Avocado"],
+    "serving_size": 400,
+    "calories": 520,
+    "protein": 20,
+    "fat": 16,
+    "carbs": 70,
+    "tags": ["Vegetarian", "High-Fiber"]
+  },
+  {
+    "dish_name": "Salmon with Roasted Vegetables",
+    "ingredients": ["Salmon Fillet", "Broccoli", "Carrots", "Sweet Potatoes"],
+    "serving_size": 380,
+    "calories": 560,
+    "protein": 42,
+    "fat": 24,
+    "carbs": 38,
+    "tags": ["High-Protein", "Gluten-Free"]
+  },
+  {
+    "dish_name": "Greek Yogurt Parfait",
+    "ingredients": ["Greek Yogurt", "Mixed Berries", "Granola", "Honey"],
+    "serving_size": 250,
+    "calories": 310,
+    "protein": 20,
+    "fat": 8,
+    "carbs": 44,
+    "tags": ["Vegetarian", "Low-Fat"]
+  },
+  {
+    "dish_name": "Tofu Stir-Fry",
+    "ingredients": ["Firm Tofu", "Brown Rice", "Snap Peas", "Soy Sauce", "Sesame Oil"],
+    "serving_size": 420,
+    "calories": 480,
+    "protein": 28,
+    "fat": 18,
+    "carbs": 58,
+    "tags": ["Vegetarian", "High-Protein"]
+  },
+  {
+    "dish_name": "Turkey and Sweet Potato Hash",
+    "ingredients": ["Ground Turkey", "Sweet Potatoes", "Onions", "Bell Peppers"],
+    "serving_size": 360,
+    "calories": 450,
+    "protein": 35,
+    "fat": 14,
+    "carbs": 46,
+    "tags": ["High-Protein", "Gluten-Free"]
+  },
+  {
+    "dish_name": "Veggie Omelette",
+    "ingredients": ["Eggs", "Spinach", "Mushrooms", "Feta Cheese"],
+    "serving_size": 280,
+    "calories": 330,
+    "protein": 24,
+    "fat": 22,
+    "carbs": 8,
+    "tags": ["Vegetarian", "Low-Carb"]
+  },
+  {
+    "dish_name": "Shrimp Brown Rice Bowl",
+    "ingredients": ["Shrimp", "Brown Rice", "Edamame", "Ginger", "Soy Sauce"],
+    "serving_size": 360,
+    "calories": 500,
+    "protein": 32,
+    "fat": 10,
+    "carbs": 72,
+    "tags": ["High-Protein", "Low-Fat"]
+  },
+  {
+    "dish_name": "Lentil Soup",
+    "ingredients": ["Lentils", "Carrots", "Celery", "Vegetable Broth"],
+    "serving_size": 320,
+    "calories": 350,
+    "protein": 22,
+    "fat": 6,
+    "carbs": 52,
+    "tags": ["Vegetarian", "Low-Fat", "High-Fiber"]
+  },
+  {
+    "dish_name": "Baked Cod with Quinoa",
+    "ingredients": ["Cod Fillet", "Quinoa", "Spinach", "Lemon"],
+    "serving_size": 340,
+    "calories": 420,
+    "protein": 36,
+    "fat": 12,
+    "carbs": 40,
+    "tags": ["High-Protein", "Low-Fat"]
+  }
+]

--- a/nutrition_cli.py
+++ b/nutrition_cli.py
@@ -1,0 +1,155 @@
+"""Command line interface for the nutrition analysis system."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+from nutrition_system import (
+    UserProfile,
+    export_plan_to_excel,
+    export_plan_to_pdf,
+    generate_macro_charts,
+    generate_meal_plans,
+    load_dish_database,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Personalized Nutrition Analysis")
+    parser.add_argument("--age", type=int, required=True, help="Age in years")
+    parser.add_argument("--gender", choices=["Male", "Female"], required=True)
+    parser.add_argument("--weight", type=float, required=True, help="Weight in kilograms")
+    parser.add_argument("--height", type=float, required=True, help="Height in centimeters")
+    parser.add_argument(
+        "--goal",
+        type=str,
+        required=True,
+        choices=["weight loss", "muscle gain", "maintenance"],
+        help="Nutrition goal",
+    )
+    parser.add_argument(
+        "--activity-level",
+        default="sedentary",
+        choices=["sedentary", "light", "moderate", "active", "very_active"],
+    )
+    parser.add_argument(
+        "--preferences",
+        type=str,
+        default="",
+        help="Comma separated dietary preferences (e.g. Vegetarian,Low-Carb)",
+    )
+    parser.add_argument(
+        "--meals",
+        type=int,
+        default=3,
+        help="Primary number of meals to generate a plan for",
+    )
+    parser.add_argument(
+        "--alt-meals",
+        type=str,
+        default="",
+        help="Additional meal counts separated by commas (e.g. 2,4,5)",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=3,
+        help="Number of alternative meal plans to display per meal count",
+    )
+    parser.add_argument(
+        "--export-dir",
+        type=str,
+        default="reports",
+        help="Directory where reports should be exported",
+    )
+    parser.add_argument(
+        "--export",
+        action="store_true",
+        help="Export best plan to Excel and PDF with charts",
+    )
+    parser.add_argument(
+        "--show-json",
+        action="store_true",
+        help="Output the plan data as JSON for automation",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    preferences: List[str] = [
+        pref.strip()
+        for pref in args.preferences.split(",")
+        if pref.strip()
+    ]
+    meal_counts = {args.meals}
+    if args.alt_meals:
+        meal_counts.update(int(val.strip()) for val in args.alt_meals.split(",") if val.strip())
+
+    profile = UserProfile(
+        age=args.age,
+        gender=args.gender,
+        weight_kg=args.weight,
+        height_cm=args.height,
+        goal=args.goal,
+        activity_level=args.activity_level,
+        dietary_preferences=preferences,
+    )
+
+    dishes = load_dish_database()
+    plans = generate_meal_plans(
+        profile,
+        dishes,
+        meals_per_day=sorted(meal_counts),
+        top_n=args.top,
+    )
+
+    output_dir = Path(args.export_dir)
+    results_to_display = {}
+    for meal_count, plan_options in plans.items():
+        print(f"\nMeal Count: {meal_count}")
+        if not plan_options:
+            print("  No matching meal plans generated within tolerance.")
+            continue
+        for index, plan in enumerate(plan_options, start=1):
+            totals = plan["totals"]
+            print(
+                f"  Option {index}: {totals['calories']:.0f} kcal | Protein: {totals['protein']:.1f}g | "
+                f"Fat: {totals['fat']:.1f}g | Carbs: {totals['carbs']:.1f}g"
+            )
+            for detail in plan["details"]:
+                print(
+                    f"    - {detail['dish_name']} ({detail['calories']} kcal, "
+                    f"{detail['protein']}g P, {detail['fat']}g F, {detail['carbs']}g C)"
+                )
+        results_to_display[meal_count] = plan_options
+
+    if args.export and results_to_display:
+        best_plans = [plans for meal, plans in results_to_display.items() if plans]
+        if best_plans:
+            best_plan = best_plans[0][0]
+            chart_paths = generate_macro_charts(
+                totals=best_plan["totals"],
+                meal_details=best_plan["details"],
+                output_dir=output_dir,
+                prefix="best_plan",
+            )
+            excel_path = export_plan_to_excel(best_plan, output_dir / "meal_plan.xlsx")
+            pdf_path = export_plan_to_pdf(
+                profile,
+                best_plan,
+                output_path=output_dir / "nutrition_report.pdf",
+                chart_paths=chart_paths,
+            )
+            print(f"\nExported Excel report to: {excel_path}")
+            print(f"Exported PDF report to: {pdf_path}")
+
+    if args.show_json:
+        json_output = json.dumps(results_to_display, indent=2)
+        print("\nJSON Output:\n" + json_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/nutrition_system.py
+++ b/nutrition_system.py
@@ -1,0 +1,430 @@
+"""Personalized nutrition analysis and meal plan recommendation system."""
+from __future__ import annotations
+
+import itertools
+import json
+import math
+import random
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+BASE_DIR = Path(__file__).resolve().parent
+DISH_DATABASE_PATH = BASE_DIR / "dish_database.json"
+
+
+GOAL_CALORIE_ADJUSTMENT = {
+    "weight loss": 0.85,
+    "weight_loss": 0.85,
+    "weight-loss": 0.85,
+    "muscle gain": 1.15,
+    "muscle_gain": 1.15,
+    "muscle-gain": 1.15,
+    "maintenance": 1.0,
+}
+
+MACRO_RATIOS = {
+    "weight loss": {"protein": 0.35, "fat": 0.25, "carbs": 0.40},
+    "weight_loss": {"protein": 0.35, "fat": 0.25, "carbs": 0.40},
+    "weight-loss": {"protein": 0.35, "fat": 0.25, "carbs": 0.40},
+    "muscle gain": {"protein": 0.30, "fat": 0.25, "carbs": 0.45},
+    "muscle_gain": {"protein": 0.30, "fat": 0.25, "carbs": 0.45},
+    "muscle-gain": {"protein": 0.30, "fat": 0.25, "carbs": 0.45},
+    "maintenance": {"protein": 0.25, "fat": 0.30, "carbs": 0.45},
+}
+
+CALORIES_PER_GRAM = {"protein": 4, "carbs": 4, "fat": 9}
+
+ACTIVITY_FACTORS = {
+    "sedentary": 1.2,
+    "light": 1.375,
+    "moderate": 1.55,
+    "active": 1.725,
+    "very_active": 1.9,
+}
+
+
+@dataclass
+class UserProfile:
+    """User profile holding demographic and goal information."""
+
+    age: int
+    gender: str
+    weight_kg: float
+    height_cm: float
+    goal: str
+    activity_level: str = "sedentary"
+    dietary_preferences: List[str] = field(default_factory=list)
+
+    @property
+    def normalized_goal(self) -> str:
+        return self.goal.replace(" ", "_").lower()
+
+    @property
+    def activity_factor(self) -> float:
+        return ACTIVITY_FACTORS.get(self.activity_level.lower(), 1.2)
+
+
+@dataclass
+class Dish:
+    """Representation of a dish entry from the database."""
+
+    dish_name: str
+    ingredients: List[str]
+    serving_size: float
+    calories: float
+    protein: float
+    fat: float
+    carbs: float
+    tags: List[str]
+
+    @staticmethod
+    def from_dict(data: Dict[str, object]) -> "Dish":
+        return Dish(
+            dish_name=str(data["dish_name"]),
+            ingredients=list(data.get("ingredients", [])),
+            serving_size=float(data.get("serving_size", 0)),
+            calories=float(data.get("calories", 0)),
+            protein=float(data.get("protein", 0)),
+            fat=float(data.get("fat", 0)),
+            carbs=float(data.get("carbs", 0)),
+            tags=[str(tag) for tag in data.get("tags", [])],
+        )
+
+
+def load_dish_database(path: Optional[Path] = None) -> List[Dish]:
+    """Load dish database entries from JSON file."""
+
+    database_path = path or DISH_DATABASE_PATH
+    with database_path.open("r", encoding="utf-8") as file:
+        data = json.load(file)
+    return [Dish.from_dict(entry) for entry in data]
+
+
+def calculate_bmr(profile: UserProfile) -> float:
+    """Calculate basal metabolic rate using the Mifflin-St Jeor formula."""
+
+    gender = profile.gender.lower()
+    if gender == "male":
+        return 10 * profile.weight_kg + 6.25 * profile.height_cm - 5 * profile.age + 5
+    if gender == "female":
+        return 10 * profile.weight_kg + 6.25 * profile.height_cm - 5 * profile.age - 161
+    raise ValueError("Gender must be 'Male' or 'Female'.")
+
+
+def calculate_tdee(profile: UserProfile) -> float:
+    """Estimate total daily energy expenditure."""
+
+    bmr = calculate_bmr(profile)
+    return bmr * profile.activity_factor
+
+
+def calculate_daily_targets(profile: UserProfile) -> Dict[str, Dict[str, float]]:
+    """Return caloric and macronutrient targets based on the user's goal."""
+
+    tdee = calculate_tdee(profile)
+    adjustment_factor = GOAL_CALORIE_ADJUSTMENT.get(profile.normalized_goal, 1.0)
+    target_calories = tdee * adjustment_factor
+    macro_ratio = MACRO_RATIOS.get(profile.normalized_goal, MACRO_RATIOS["maintenance"])
+
+    macro_targets = {
+        macro: (target_calories * ratio) / CALORIES_PER_GRAM[macro]
+        for macro, ratio in macro_ratio.items()
+    }
+
+    return {
+        "bmr": calculate_bmr(profile),
+        "tdee": tdee,
+        "target_calories": target_calories,
+        "macro_targets": macro_targets,
+        "macro_ratio": macro_ratio,
+    }
+
+
+def filter_dishes_by_preferences(dishes: Iterable[Dish], preferences: Sequence[str]) -> List[Dish]:
+    """Filter dishes that satisfy all dietary preferences."""
+
+    preferences_normalized = {pref.lower() for pref in preferences}
+    if not preferences_normalized:
+        return list(dishes)
+    filtered = [
+        dish
+        for dish in dishes
+        if preferences_normalized.issubset({tag.lower() for tag in dish.tags})
+    ]
+    return filtered
+
+
+def _plan_score(aggregated: Dict[str, float], targets: Dict[str, float]) -> float:
+    """Calculate a score representing closeness to targets."""
+
+    calorie_diff = abs(aggregated["calories"] - targets["calories"]) / targets["calories"]
+    protein_diff = abs(aggregated["protein"] - targets["protein"]) / targets["protein"]
+    fat_diff = abs(aggregated["fat"] - targets["fat"]) / targets["fat"]
+    carbs_diff = abs(aggregated["carbs"] - targets["carbs"]) / targets["carbs"]
+    return calorie_diff + protein_diff + fat_diff + carbs_diff
+
+
+def _aggregate_dishes(dishes: Sequence[Dish]) -> Dict[str, float]:
+    return {
+        "calories": sum(dish.calories for dish in dishes),
+        "protein": sum(dish.protein for dish in dishes),
+        "fat": sum(dish.fat for dish in dishes),
+        "carbs": sum(dish.carbs for dish in dishes),
+    }
+
+
+def generate_meal_plans(
+    profile: UserProfile,
+    dishes: Sequence[Dish],
+    meals_per_day: Sequence[int] = (3,),
+    tolerance: float = 0.4,
+    top_n: int = 3,
+) -> Dict[int, List[Dict[str, object]]]:
+    """Generate suitable meal plans based on targets and preferences."""
+
+    targets_info = calculate_daily_targets(profile)
+    targets = {
+        "calories": targets_info["target_calories"],
+        "protein": targets_info["macro_targets"]["protein"],
+        "fat": targets_info["macro_targets"]["fat"],
+        "carbs": targets_info["macro_targets"]["carbs"],
+    }
+
+    filtered_dishes = filter_dishes_by_preferences(dishes, profile.dietary_preferences)
+    if not filtered_dishes:
+        raise ValueError("No dishes available that match the provided dietary preferences.")
+
+    results: Dict[int, List[Dict[str, object]]] = {}
+    for meal_count in meals_per_day:
+        combinations = itertools.combinations(filtered_dishes, meal_count)
+        scored_plans: List[Tuple[float, Dict[str, object]]] = []
+        for combo in combinations:
+            aggregated = _aggregate_dishes(combo)
+            if not _within_tolerance(aggregated, targets, tolerance):
+                continue
+            score = _plan_score(aggregated, targets)
+            scored_plans.append(
+                (
+                    score,
+                    {
+                        "meals": [dish.dish_name for dish in combo],
+                        "totals": aggregated,
+                        "details": [
+                            {
+                                "dish_name": dish.dish_name,
+                                "calories": dish.calories,
+                                "protein": dish.protein,
+                                "fat": dish.fat,
+                                "carbs": dish.carbs,
+                                "tags": dish.tags,
+                            }
+                            for dish in combo
+                        ],
+                    },
+                )
+            )
+        scored_plans.sort(key=lambda item: item[0])
+        results[meal_count] = [plan for _, plan in scored_plans[:top_n]]
+    return results
+
+
+def _within_tolerance(
+    aggregated: Dict[str, float], targets: Dict[str, float], tolerance: float
+) -> bool:
+    return all(
+        math.isclose(aggregated[key], targets[key], rel_tol=tolerance)
+        for key in ("calories", "protein", "fat", "carbs")
+    )
+
+
+def generate_macro_charts(
+    totals: Dict[str, float],
+    meal_details: Sequence[Dict[str, float]],
+    output_dir: Path,
+    prefix: str,
+) -> Dict[str, Path]:
+    """Create pie and bar charts for macro distribution using matplotlib."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    import matplotlib.pyplot as plt  # imported lazily to avoid hard dependency elsewhere
+
+    pie_path = output_dir / f"{prefix}_macros_pie.png"
+    bar_path = output_dir / f"{prefix}_meals_bar.png"
+
+    macros = ["protein", "fat", "carbs"]
+    values = [totals[macro] for macro in macros]
+
+    plt.figure(figsize=(6, 6))
+    plt.pie(values, labels=macros, autopct="%1.1f%%")
+    plt.title("Macronutrient Distribution")
+    plt.savefig(pie_path)
+    plt.close()
+
+    plt.figure(figsize=(8, 6))
+    meal_names = [meal["dish_name"] for meal in meal_details]
+    calories = [meal["calories"] for meal in meal_details]
+    protein = [meal["protein"] for meal in meal_details]
+    fat = [meal["fat"] for meal in meal_details]
+    carbs = [meal["carbs"] for meal in meal_details]
+
+    indices = range(len(meal_names))
+    plt.bar([i - 0.2 for i in indices], protein, width=0.2, label="Protein (g)")
+    plt.bar(indices, fat, width=0.2, label="Fat (g)")
+    plt.bar([i + 0.2 for i in indices], carbs, width=0.2, label="Carbs (g)")
+    plt.xticks(list(indices), meal_names, rotation=45, ha="right")
+    plt.ylabel("Grams")
+    plt.title("Meal-Level Macronutrients")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(bar_path)
+    plt.close()
+
+    return {"pie_chart": pie_path, "bar_chart": bar_path}
+
+
+def export_plan_to_excel(plan: Dict[str, object], output_path: Path) -> Path:
+    """Export meal plan to an Excel file using openpyxl."""
+
+    from openpyxl import Workbook
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "Meal Plan"
+
+    sheet.append(["Dish Name", "Calories", "Protein (g)", "Fat (g)", "Carbs (g)"])
+    for detail in plan["details"]:
+        sheet.append(
+            [
+                detail["dish_name"],
+                detail["calories"],
+                detail["protein"],
+                detail["fat"],
+                detail["carbs"],
+            ]
+        )
+
+    totals = plan["totals"]
+    sheet.append([])
+    sheet.append(["Totals", totals["calories"], totals["protein"], totals["fat"], totals["carbs"]])
+
+    workbook.save(output_path)
+    return output_path
+
+
+def export_plan_to_pdf(
+    profile: UserProfile,
+    plan: Dict[str, object],
+    output_path: Path,
+    chart_paths: Optional[Dict[str, Path]] = None,
+) -> Path:
+    """Export a nutrition analysis report to a PDF file."""
+
+    from matplotlib import pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with PdfPages(output_path) as pdf:
+        plt.figure(figsize=(8.5, 11))
+        plt.axis("off")
+        totals = plan["totals"]
+        text_lines = [
+            "Personalized Nutrition Analysis",
+            "",
+            f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')} UTC",
+            "",
+            f"User Profile:",
+            f"  Age: {profile.age}",
+            f"  Gender: {profile.gender}",
+            f"  Weight: {profile.weight_kg} kg",
+            f"  Height: {profile.height_cm} cm",
+            f"  Goal: {profile.goal}",
+            f"  Activity Level: {profile.activity_level}",
+            "",
+            "Daily Targets (approx.):",
+            f"  Calories: {totals['calories']:.0f} kcal",
+            f"  Protein: {totals['protein']:.1f} g",
+            f"  Fat: {totals['fat']:.1f} g",
+            f"  Carbs: {totals['carbs']:.1f} g",
+            "",
+            "Meal Plan:" if plan["details"] else "No meals found",
+        ]
+        for detail in plan["details"]:
+            text_lines.append(
+                f"  - {detail['dish_name']}: {detail['calories']} kcal, {detail['protein']}g protein, {detail['fat']}g fat, {detail['carbs']}g carbs"
+            )
+
+        plt.text(0.05, 0.95, "\n".join(text_lines), va="top", fontsize=12)
+        pdf.savefig()
+        plt.close()
+
+        if chart_paths:
+            for chart in chart_paths.values():
+                if chart.exists():
+                    image = plt.imread(chart)
+                    plt.figure(figsize=(8.5, 11))
+                    plt.imshow(image)
+                    plt.axis("off")
+                    pdf.savefig()
+                    plt.close()
+    return output_path
+
+
+def generate_synthetic_user_dataset(
+    num_entries: int, output_path: Optional[Path] = None
+) -> List[Dict[str, object]]:
+    """Generate a synthetic dataset of user profiles for testing."""
+
+    profiles = []
+    possible_goals = list(GOAL_CALORIE_ADJUSTMENT.keys())
+    genders = ["Male", "Female"]
+    activity_levels = list(ACTIVITY_FACTORS.keys())
+
+    dishes = load_dish_database()
+    for _ in range(num_entries):
+        profile = UserProfile(
+            age=random.randint(18, 70),
+            gender=random.choice(genders),
+            weight_kg=random.uniform(50, 110),
+            height_cm=random.uniform(150, 200),
+            goal=random.choice(possible_goals),
+            activity_level=random.choice(activity_levels),
+        )
+        targets = calculate_daily_targets(profile)
+        preferences = []
+        if random.random() < 0.4:
+            preference_pool = {
+                tag.lower() for dish in dishes for tag in dish.tags
+            }
+            if preference_pool:
+                preferences.append(random.choice(sorted(preference_pool)))
+        profiles.append(
+            {
+                "age": profile.age,
+                "gender": profile.gender,
+                "weight_kg": round(profile.weight_kg, 1),
+                "height_cm": round(profile.height_cm, 1),
+                "goal": profile.goal,
+                "activity_level": profile.activity_level,
+                "dietary_preferences": preferences,
+                "targets": {
+                    "bmr": round(targets["bmr"], 1),
+                    "tdee": round(targets["tdee"], 1),
+                    "calories": round(targets["target_calories"], 1),
+                    "protein_g": round(targets["macro_targets"]["protein"], 1),
+                    "fat_g": round(targets["macro_targets"]["fat"], 1),
+                    "carbs_g": round(targets["macro_targets"]["carbs"], 1),
+                },
+            }
+        )
+
+    if output_path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as file:
+            json.dump(profiles, file, indent=2)
+
+    return profiles

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib>=3.6
+openpyxl>=3.1

--- a/tests/test_nutrition_system.py
+++ b/tests/test_nutrition_system.py
@@ -1,0 +1,117 @@
+import json
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from nutrition_system import (
+    UserProfile,
+    calculate_bmr,
+    calculate_daily_targets,
+    export_plan_to_excel,
+    export_plan_to_pdf,
+    generate_macro_charts,
+    generate_meal_plans,
+    generate_synthetic_user_dataset,
+    load_dish_database,
+)
+
+
+class NutritionSystemTests(TestCase):
+    def setUp(self) -> None:
+        self.profile = UserProfile(
+            age=32,
+            gender="Female",
+            weight_kg=62,
+            height_cm=165,
+            goal="weight loss",
+            activity_level="light",
+        )
+        self.dishes = load_dish_database()
+
+    def test_calculate_bmr(self) -> None:
+        bmr = calculate_bmr(self.profile)
+        self.assertAlmostEqual(bmr, 1330.25, places=2)
+
+    def test_daily_targets_structure(self) -> None:
+        targets = calculate_daily_targets(self.profile)
+        self.assertIn("target_calories", targets)
+        macro_targets = targets["macro_targets"]
+        self.assertGreater(macro_targets["protein"], 0)
+        self.assertGreater(macro_targets["fat"], 0)
+        self.assertGreater(macro_targets["carbs"], 0)
+
+    def test_generate_meal_plan(self) -> None:
+        plans = generate_meal_plans(
+            self.profile,
+            self.dishes,
+            meals_per_day=[3],
+            top_n=2,
+            tolerance=0.5,
+        )
+        self.assertIn(3, plans)
+        self.assertTrue(plans[3])
+        plan = plans[3][0]
+        self.assertIn("details", plan)
+        self.assertTrue(all("dish_name" in detail for detail in plan["details"]))
+
+    def test_dietary_preferences(self) -> None:
+        vegetarian_profile = UserProfile(
+            age=28,
+            gender="Male",
+            weight_kg=75,
+            height_cm=180,
+            goal="maintenance",
+            activity_level="moderate",
+            dietary_preferences=["Vegetarian"],
+        )
+        plans = generate_meal_plans(
+            vegetarian_profile,
+            self.dishes,
+            meals_per_day=[2],
+            top_n=1,
+            tolerance=1.0,
+        )
+        self.assertTrue(plans[2])
+        plan = plans[2][0]
+        for detail in plan["details"]:
+            self.assertIn("Vegetarian", detail["tags"])  # only vegetarian dishes should appear
+
+    def test_export_functions(self) -> None:
+        plans = generate_meal_plans(
+            self.profile,
+            self.dishes,
+            meals_per_day=[3],
+            top_n=1,
+            tolerance=0.5,
+        )
+        plan = plans[3][0]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            chart_paths = generate_macro_charts(
+                totals=plan["totals"],
+                meal_details=plan["details"],
+                output_dir=tmp_path,
+                prefix="test",
+            )
+            for path in chart_paths.values():
+                self.assertTrue(path.exists())
+            excel_file = export_plan_to_excel(plan, tmp_path / "plan.xlsx")
+            self.assertTrue(excel_file.exists())
+            pdf_file = export_plan_to_pdf(
+                self.profile,
+                plan,
+                output_path=tmp_path / "plan.pdf",
+                chart_paths=chart_paths,
+            )
+            self.assertTrue(pdf_file.exists())
+
+    def test_synthetic_dataset_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_file = Path(tmp_dir) / "synthetic_users.json"
+            dataset = generate_synthetic_user_dataset(5, output_path=output_file)
+            self.assertEqual(len(dataset), 5)
+            self.assertTrue(output_file.exists())
+            with output_file.open("r", encoding="utf-8") as file:
+                loaded = json.load(file)
+            self.assertEqual(len(loaded), 5)
+            self.assertIn("targets", loaded[0])


### PR DESCRIPTION
**Overview**  
Introduce a complete nutrition analysis workflow that consumes user profiles, estimates caloric and macronutrient requirements, recommends goal-aligned meal plans, and exports reports with visualizations. Users can now run the CLI or modules directly to generate PDF/Excel outputs that honor dietary preferences.

**Reviewer Guidance**  
- Implement nutrition analytics and planning logic  
  - Add `nutrition_system.py` with calculation helpers (`calculate_bmr`, `calculate_daily_targets`), meal plan generation that respects optional dietary tags, chart creation, PDF/Excel export utilities, and synthetic dataset support to enable end-to-end functionality.  
  - Provide `dish_database.json` as the structured source of dishes and nutritional macros used throughout the recommendation pipeline.  
- Expose a CLI workflow and documentation  
  - Create `nutrition_cli.py` to gather arguments, run plan generation, display alternatives, and optionally export artifacts in the `reports/` directory, allowing interactive use.  
  - Update `README.md` with setup instructions, example CLI invocation, and API usage for dataset generation.  
- Add tests and developer tooling  
  - Introduce `tests/test_nutrition_system.py` (plus `tests/__init__.py`) covering calculations, preference filtering, exports, and dataset generation to protect core behavior.  
  - Track dependencies in `requirements.txt` (matplotlib/openpyxl) and ignore Python cache directories via `.gitignore`.

Suggested Order for Reviewing: start with `nutrition_system.py` (core logic), then inspect `nutrition_cli.py` (entrypoint), followed by `dish_database.json` for data. Finally, review tests in `tests/test_nutrition_system.py` and documentation updates.

**Setup and Usage**  
```bash
pip install -r requirements.txt
python nutrition_cli.py --age 30 --gender Male --weight 82 --height 182 \
  --goal "muscle gain" --activity-level moderate --preferences Vegetarian \
  --meals 3 --alt-meals 2,4 --top 2 --export --show-json
```

**Validation and Testing**  
- Unit Tests: `python -m unittest tests.test_nutrition_system`  
- Full Discovery: `python -m unittest discover`  
Both commands should pass after installing dependencies.

**Risk, Errors, Limits & Rollback**  
Risk Level: Medium. Dependent on dish combinations; extreme preferences may yield no plan (handled with a descriptive error). Rollback by removing the new module, CLI, tests, dataset, and requirements entry while restoring the original README and gitignore.

Closes #65